### PR TITLE
Adds basic (but heinously dirty) pronoun support, plus body and voice-type preferences

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -112,3 +112,17 @@
 
 #define ALL_AGES_LIST list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 
+// Pronouns (LETHALSTONE)
+#define HE_HIM			"he/him"
+#define SHE_HER			"she/her"
+#define THEY_THEM		"they/them"
+#define IT_ITS			"it/its"
+
+GLOBAL_LIST_INIT(pronouns_list, list(HE_HIM, SHE_HER, THEY_THEM, IT_ITS))
+
+// Voice types (LETHALSTONE)
+
+#define VOICE_TYPE_MASC	"Masculine"
+#define VOICE_TYPE_FEM	"Feminine"
+
+GLOBAL_LIST_INIT(voice_types_list, list(VOICE_TYPE_MASC, VOICE_TYPE_FEM))

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -225,6 +225,7 @@ GLOBAL_LIST_EMPTY(species_list)
 
 /mob
 	var/doing = 0
+	var/pronouns = null // LETHALSTONE ADDITION: this is cheap so i'm doing it. preferences in human will set this appropriately
 
 /proc/do_after(mob/user, delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null)
 	if(!user)

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -116,6 +116,8 @@
 	if(temp_gender != PLURAL && temp_gender != NEUTER)
 		. = "es"
 
+// LETHALSTONE NOTE: hello! we always return early on PLURAL check here because it's always correct (human mob overrides set it for disguises) and respects disguises. causes some code duplication though
+
 //mobs(and atoms but atoms don't really matter write your own proc overrides) also have gender!
 /mob/p_they(capitalized, temp_gender)
 	if(!temp_gender)
@@ -128,6 +130,22 @@
 			. = "he"
 		if(PLURAL)
 			. = "they"
+			if (capitalized)
+				. = capitalize(.)
+			return
+
+	// LETHALSTONE EDIT: if our mob has pronouns, use those instead
+	if (pronouns) 
+		switch (pronouns)
+			if (HE_HIM)
+				. = "he"
+			if (SHE_HER)
+				. = "she"
+			if (THEY_THEM)
+				. = "they"
+			if (IT_ITS)
+				. = "it"
+	// LETHALSTONE EDIT END
 	if(capitalized)
 		. = capitalize(.)
 
@@ -142,6 +160,22 @@
 			. = "his"
 		if(PLURAL)
 			. = "their"
+			if (capitalized)
+				. = capitalize(.)
+			return
+
+	// LETHALSTONE EDIT: if our mob has pronouns, use those instead
+	if (pronouns) 
+		switch (pronouns)
+			if (HE_HIM)
+				. = "his"
+			if (SHE_HER)
+				. = "her"
+			if (THEY_THEM)
+				. = "their"
+			if (IT_ITS)
+				. = "its"
+	// LETHALSTONE EDIT END
 	if(capitalized)
 		. = capitalize(.)
 
@@ -156,6 +190,21 @@
 			. = "him"
 		if(PLURAL)
 			. = "them"
+			if (capitalized)
+				. = capitalize(.)
+			return
+	// LETHALSTONE EDIT: if our mob has pronouns, use those instead
+	if (pronouns) 
+		switch (pronouns)
+			if (HE_HIM)
+				. = "him"
+			if (SHE_HER)
+				. = "her"
+			if (THEY_THEM)
+				. = "them"
+			if (IT_ITS)
+				. = "it"
+	// LETHALSTONE EDIT END
 	if(capitalized)
 		. = capitalize(.)
 
@@ -165,6 +214,12 @@
 	. = "has"
 	if(temp_gender == PLURAL)
 		. = "have"
+		return
+	// LETHALSTONE EDIT: use pronouns where possible
+	if (pronouns)
+		if (pronouns == THEY_THEM)
+			. = "have"
+	// LETHALSTONE EDIT END
 
 /mob/p_are(temp_gender)
 	if(!temp_gender)
@@ -172,6 +227,12 @@
 	. = "is"
 	if(temp_gender == PLURAL)
 		. = "are"
+		return
+	// LETHALSTONE EDIT: use pronouns where possible
+	if (pronouns)
+		if (pronouns == THEY_THEM)
+			. = "are"
+	// LETHALSTONE EDIT END
 
 /mob/p_were(temp_gender)
 	if(!temp_gender)
@@ -179,6 +240,12 @@
 	. = "was"
 	if(temp_gender == PLURAL)
 		. = "were"
+		return
+	// LETHALSTONE EDIT: use pronouns where possible
+	if (pronouns)
+		if (pronouns == THEY_THEM)
+			. = "were"
+	// LETHALSTONE EDIT END
 
 /mob/p_do(temp_gender)
 	if(!temp_gender)
@@ -186,18 +253,34 @@
 	. = "does"
 	if(temp_gender == PLURAL)
 		. = "do"
+		return
+	// LETHALSTONE EDIT: use pronouns where possible
+	if (pronouns)
+		if (pronouns == THEY_THEM)
+			. = "do"
+	// LETHALSTONE EDIT END
 
 /mob/p_s(temp_gender)
 	if(!temp_gender)
 		temp_gender = gender
 	if(temp_gender != PLURAL)
 		. = "s"
+	// LETHALSTONE EDIT: use pronouns where possible
+	if (pronouns)
+		if (pronouns != THEY_THEM)
+			. = "s"
+	// LETHALSTONE EDIT END
 
 /mob/p_es(temp_gender)
 	if(!temp_gender)
 		temp_gender = gender
 	if(temp_gender != PLURAL)
 		. = "es"
+	// LETHALSTONE EDIT: use pronouns where possible
+	if (pronouns)
+		if (pronouns != THEY_THEM)
+			. = "es"
+	// LETHALSTONE EDIT END
 
 //humans need special handling, because they can have their gender hidden
 /mob/living/carbon/human/p_they(capitalized, temp_gender)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -148,6 +148,17 @@
 				possible_sounds = H.dna.species.soundpack_f.get_sound(key,modifier)
 			else if(H.dna.species.soundpack_m)
 				possible_sounds = H.dna.species.soundpack_m.get_sound(key,modifier)
+			 // LETHALSTONE ADDITION BEGIN: use preference-set voice types where possible
+			if(H.voice_type)
+				switch (H.voice_type)
+					if (VOICE_TYPE_MASC)
+						possible_sounds = H.dna.species.soundpack_m.get_sound(key, modifier)
+					if (VOICE_TYPE_FEM)
+						if (H.dna.species.soundpack_f)
+							possible_sounds = H.dna.species.soundpack_f.get_sound(key, modifier)
+						else
+							possible_sounds = H.dna.species.soundpack_m.get_sound(key, modifier)
+			// LETHALSTONE ADDITION END
 			if(possible_sounds)
 				if(islist(possible_sounds))
 					var/list/PS = possible_sounds

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/static/datum/patron/default_patron = /datum/patron/divine/astrata
 	var/list/features = MANDATORY_FEATURE_LIST
 	var/list/randomise = list(RANDOM_UNDERWEAR = TRUE, RANDOM_UNDERWEAR_COLOR = TRUE, RANDOM_UNDERSHIRT = TRUE, RANDOM_SOCKS = TRUE, RANDOM_BACKPACK = TRUE, RANDOM_JUMPSUIT_STYLE = FALSE, RANDOM_SKIN_TONE = TRUE, RANDOM_EYE_COLOR = TRUE)
-	var/list/friendlyGenders = list("Masculine" = "male", "Feminine" = "female")
+	var/list/friendlyGenders = list("male" = "masculine", "female" = "feminine")
 	var/phobia = "spiders"
 	var/shake = TRUE
 	var/sexable = FALSE
@@ -327,6 +327,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 				dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a> <a href='?_src_=prefs;preference=name;task=random'>\[R\]</a>"
 
 			// LETHALSTONE EDIT BEGIN: add pronoun prefs
+			dat += "<BR>"
 			dat += "<b>Pronouns:</b> <a href='?_src_=prefs;preference=pronouns;task=input'>[pronouns]</a><BR>"
 			// LETHALSTONE EDIT END
 
@@ -1738,7 +1739,8 @@ Slots: [job.spawn_positions]</span>
 					if(pickedGender && pickedGender != gender)
 						gender = pickedGender
 						ResetJobs()
-						to_chat(user, "<font color='red'>Classes reset.</font>")
+						to_chat(user, "<font color='red'>Your character will now use a [friendlyGenders[pickedGender]] sprite.")
+						to_chat(user, "<font color='red'><b>Your classes have been reset.</b></font>")
 						random_character(gender)
 					genderize_customizer_entries()
 				if("domhand")
@@ -2079,9 +2081,10 @@ Slots: [job.spawn_positions]</span>
 
 	character.headshot_link = headshot_link
 
-	// LETHALSTONE ADDITION BEGIN: pronouns
+	// LETHALSTONE ADDITION BEGIN: additional customizations
 
 	character.pronouns = pronouns
+	character.voice_type = voice_type
 
 	// LETHALSTONE ADDITION END
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -64,7 +64,9 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	//character preferences
 	var/slot_randomized					//keeps track of round-to-round randomization of the character slot, prevents overwriting
 	var/real_name						//our character's name
-	var/gender = MALE					//gender of character (well duh)
+	var/gender = MALE					//gender of character (well duh) (LETHALSTONE EDIT: this no longer references anything but whether the masculine or feminine model is used)
+	var/pronouns = HE_HIM				// LETHALSTONE EDIT: character's pronouns (well duh)
+	var/voice_type = VOICE_TYPE_MASC	// LETHALSTONE EDIT: the type of soundpack the mob should use
 	var/age = AGE_ADULT						//age of character
 	var/origin = "Default"
 	var/underwear = "Nude"				//underwear type
@@ -89,7 +91,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/static/datum/patron/default_patron = /datum/patron/divine/astrata
 	var/list/features = MANDATORY_FEATURE_LIST
 	var/list/randomise = list(RANDOM_UNDERWEAR = TRUE, RANDOM_UNDERWEAR_COLOR = TRUE, RANDOM_UNDERSHIRT = TRUE, RANDOM_SOCKS = TRUE, RANDOM_BACKPACK = TRUE, RANDOM_JUMPSUIT_STYLE = FALSE, RANDOM_SKIN_TONE = TRUE, RANDOM_EYE_COLOR = TRUE)
-	var/list/friendlyGenders = list("Male" = "male", "Female" = "female")
+	var/list/friendlyGenders = list("Masculine" = "male", "Feminine" = "female")
 	var/phobia = "spiders"
 	var/shake = TRUE
 	var/sexable = FALSE
@@ -324,6 +326,10 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			else
 				dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a> <a href='?_src_=prefs;preference=name;task=random'>\[R\]</a>"
 
+			// LETHALSTONE EDIT BEGIN: add pronoun prefs
+			dat += "<b>Pronouns:</b> <a href='?_src_=prefs;preference=pronouns;task=input'>[pronouns]</a><BR>"
+			// LETHALSTONE EDIT END
+
 			dat += "<BR>"
 			dat += "<b>Race:</b> <a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a>[spec_check(user) ? "" : " (!)"]<BR>"
 //			dat += "<a href='?_src_=prefs;preference=species;task=random'>Random Species</A> "
@@ -332,15 +338,19 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			if(!(AGENDER in pref_species.species_traits))
 				var/dispGender
 				if(gender == MALE)
-					dispGender = "Man"
+					dispGender = "Masculine" // LETHALSTONE EDIT: repurpose gender as bodytype, display accordingly
 				else if(gender == FEMALE)
-					dispGender = "Woman"
+					dispGender = "Feminine" // LETHALSTONE EDIT: repurpose gender as bodytype, display accordingly
 				else
 					dispGender = "Other"
-				dat += "<b>Sex:</b> <a href='?_src_=prefs;preference=gender'>[dispGender]</a><BR>"
+				dat += "<b>Body Type:</b> <a href='?_src_=prefs;preference=gender'>[dispGender]</a><BR>"
 				if(randomise[RANDOM_BODY] || randomise[RANDOM_BODY_ANTAG]) //doesn't work unless random body
-					dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_GENDER]'>Always Random Gender: [(randomise[RANDOM_GENDER]) ? "Yes" : "No"]</A>"
+					dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_GENDER]'>Always Random Bodytype: [(randomise[RANDOM_GENDER]) ? "Yes" : "No"]</A>"
 					dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_GENDER_ANTAG]'>When Antagonist: [(randomise[RANDOM_GENDER_ANTAG]) ? "Yes" : "No"]</A>"
+
+			// LETHALSTONE EDIT BEGIN: add voice type prefs
+			dat += "<b>Voice Type</b>: <a href='?_src_=prefs;preference=voicetype;task=input'>[voice_type]</a><BR>"
+			// LETHALSTONE EDIT END
 
 			dat += "<b>Age:</b> <a href='?_src_=prefs;preference=age;task=input'>[age]</a><BR>"
 
@@ -1477,6 +1487,20 @@ Slots: [job.spawn_positions]</span>
 						ResetJobs()
 						to_chat(user, "<font color='red'>Classes reset.</font>")
 
+				// LETHALSTONE EDIT: add pronouns
+				if ("pronouns")
+					var pronouns_input = input(user, "Choose your character's pronouns", "Pronouns") as null|anything in GLOB.pronouns_list
+					if(pronouns_input)
+						pronouns = pronouns_input
+						to_chat(user, "<font color='red'>Your character's pronouns are now [pronouns].")
+
+				// LETHALSTONE EDIT: add voice type selection
+				if ("voicetype")
+					var voicetype_input = input(user, "Choose your character's voice type", "Voice Type") as null|anything in GLOB.voice_types_list
+					if(voicetype_input)
+						voice_type = voicetype_input
+						to_chat(user, "<font color='red'>Your character will now vocalize with a [lowertext(voice_type)] affect.")
+
 				if("faith")
 					var/list/faiths_named = list()
 					for(var/path as anything in GLOB.preference_faiths)
@@ -2054,6 +2078,12 @@ Slots: [job.spawn_positions]</span>
 	character.dna.real_name = character.real_name
 
 	character.headshot_link = headshot_link
+
+	// LETHALSTONE ADDITION BEGIN: pronouns
+
+	character.pronouns = pronouns
+
+	// LETHALSTONE ADDITION END
 
 	if(parent)
 		var/list/L = get_player_curses(parent.ckey)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -572,7 +572,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["update_mutant_colors"] , update_mutant_colors)
 	WRITE_FILE(S["headshot_link"] , headshot_link)
 	WRITE_FILE(S["pronouns"] , pronouns)
-	WRITE_FILE(S["voice_type"], voice_type)
+	WRITE_FILE(S["voice_type"] , voice_type)
 
 	WRITE_FILE(S["is_updated_for_genitalia"], TRUE)
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -338,22 +338,24 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["eye_color"]			>> eye_color
 	S["voice_color"]		>> voice_color
 	S["skin_tone"]			>> skin_tone
-	S["hairstyle_name"]	>> hairstyle
+	S["hairstyle_name"]		>> hairstyle
 	S["facial_style_name"]	>> facial_hairstyle
 	S["underwear"]			>> underwear
 	S["underwear_color"]	>> underwear_color
 	S["undershirt"]			>> undershirt
 	S["accessory"]			>> accessory
-	S["detail"]			>> detail
+	S["detail"]				>> detail
 	S["socks"]				>> socks
 	S["backpack"]			>> backpack
 	S["jumpsuit_style"]		>> jumpsuit_style
 	S["uplink_loc"]			>> uplink_spawn_loc
-	S["randomise"]	>>  randomise
-	S["feature_mcolor"]					>> features["mcolor"]
-	S["feature_mcolor2"]					>> features["mcolor2"]
-	S["feature_mcolor3"]					>> features["mcolor3"]
-	S["feature_ethcolor"]					>> features["ethcolor"]
+	S["randomise"]			>> randomise
+	S["feature_mcolor"]		>> features["mcolor"]
+	S["feature_mcolor2"]	>> features["mcolor2"]
+	S["feature_mcolor3"]	>> features["mcolor3"]
+	S["feature_ethcolor"]	>> features["ethcolor"]
+	S["pronouns"]			>> pronouns
+	S["voice_type"]			>> voice_type
 
 /datum/preferences/proc/load_character(slot)
 	if(!path)
@@ -424,6 +426,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(!valid_headshot_link(null, headshot_link, TRUE))
 		headshot_link = null
 
+	S["pronouns"] >> pronouns
+	S["voice_type"] >> voice_type
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
@@ -462,6 +466,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	backpack			= sanitize_inlist(backpack, GLOB.backpacklist, initial(backpack))
 	jumpsuit_style	= sanitize_inlist(jumpsuit_style, GLOB.jumpsuitlist, initial(jumpsuit_style))
 	uplink_spawn_loc = sanitize_inlist(uplink_spawn_loc, GLOB.uplink_spawn_loc_list, initial(uplink_spawn_loc))
+	pronouns = sanitize_text(pronouns, THEY_THEM)
+	voice_type = sanitize_text(voice_type, VOICE_TYPE_MASC)
 	features["mcolor"]	= sanitize_hexcolor(features["mcolor"], 6, 0)
 	features["mcolor2"]	= sanitize_hexcolor(features["mcolor2"], 6, 0)
 	features["mcolor3"]	= sanitize_hexcolor(features["mcolor3"], 6, 0)
@@ -565,6 +571,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	
 	WRITE_FILE(S["update_mutant_colors"] , update_mutant_colors)
 	WRITE_FILE(S["headshot_link"] , headshot_link)
+	WRITE_FILE(S["pronouns"] , pronouns)
+	WRITE_FILE(S["voice_type"], voice_type)
 
 	WRITE_FILE(S["is_updated_for_genitalia"], TRUE)
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -121,3 +121,5 @@
 	/datum/rmb_intent/weak)
 
 	rot_type = /datum/component/rot/corpse
+
+	var/voice_type = null // LETHALSTONE EDIT: defines what sound pack we use. keep this null so mobs resort to their typical gender typing - preferences set this

--- a/code/modules/mob/living/living_descriptors.dm
+++ b/code/modules/mob/living/living_descriptors.dm
@@ -114,6 +114,22 @@
 		him_replace = "him"
 	else
 		him_replace = "her"
+	// LETHALSTONE EDIT: pronoun support
+	if (described.pronouns)
+		switch (described.pronouns)
+			if (HE_HIM)
+				they_replace = "he"
+				man_replace = "man"
+				him_replace = "him"
+			if (SHE_HER)
+				they_replace = "she"
+				man_replace = "woman"
+				him_replace = "her"
+			if (THEY_THEM)
+				they_replace = "they"
+				man_replace = "person"
+				him_replace = "them"
+	// LETHALSTONE EDIT END
 	string = replacetext(string, "%THEY%", they_replace)
 	string = replacetext(string, "%HAVE%", "has")
 	string = replacetext(string, "%MAN%", man_replace)


### PR DESCRIPTION
This lets you:
- Choose whether your character has a masculine (male) or feminine (female) sprite.
- Choose whether your character uses the male or female voice pack for a given race. Note: some races don't have female voicepacks and will default to the male, but this is base RT behavior and not anything I've added.
- Allows you to choose from he/him, she/her, they/them and it/its pronouns.

Low-level pronoun procs are altered by this, so it is obviously non-modular, but should *theoretically* work anywhere that a sane programmer has used the `p_` helper procs properly.

Future changes will decouple the stat changes that jobs make based on male/female gender away completely and out into their own prefs. Just wanted to get this out for now.