### PR TITLE
Pie In The Sky: cooking improvements

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -13,6 +13,7 @@
 #define PINEAPPLE	(1<<12)
 #define BREAKFAST	(1<<13)
 #define CLOTH 		(1<<14)
+#define EGG			(1<<15)
 
 #define DRINK_NICE	1
 #define DRINK_GOOD	2

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -22,40 +22,7 @@
 
 /atom/movable/screen/alert/status_effect/buff/foodbuff
 	name = "Great Meal"
-	desc = "Above-average fare, a rarity in a land like Enigma."
-	icon_state = "foodbuff"
-
-/datum/status_effect/buff/foodbuff/lavish
-	id = "foodbuff"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/lavish
-	effectedstats = list("constitution" = 1, "endurance" = 1, "strength" = 1)
-	duration = 20 MINUTES
-
-/atom/movable/screen/alert/status_effect/buff/foodbuff/lavish
-	name = "Lavish Meal"
-	desc = "A meal fit for a king!"
-	icon_state = "foodbuff"
-
-/datum/status_effect/buff/foodbuff/sweet
-	id = "foodbuff-dessert"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/sweet
-	effectedstats = list("perception" = 1,"intelligence" = 1)
-	duration = 10 MINUTES
-
-/atom/movable/screen/alert/status_effect/buff/foodbuff/sweet
-	name = "Great Treat"
-	desc = "Something sweet is a rare treat indeed, and helps hone the mind."
-	icon_state = "foodbuff"
-
-/datum/status_effect/buff/foodbuff/sweet/lavish
-	id = "foodbuff-dessert"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/sweet/lavish
-	effectedstats = list("perception" = 1,"intelligence" = 1, "speed" = 1)
-	duration = 10 MINUTES
-
-/atom/movable/screen/alert/status_effect/buff/foodbuff/sweet/lavish
-	name = "Decadent Treat"
-	desc = "An exquisite dessert really is something!"
+	desc = ""
 	icon_state = "foodbuff"
 
 /datum/status_effect/buff/druqks

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -22,7 +22,40 @@
 
 /atom/movable/screen/alert/status_effect/buff/foodbuff
 	name = "Great Meal"
-	desc = ""
+	desc = "Above-average fare, a rarity in a land like Enigma."
+	icon_state = "foodbuff"
+
+/datum/status_effect/buff/foodbuff/lavish
+	id = "foodbuff"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/lavish
+	effectedstats = list("constitution" = 1, "endurance" = 1, "strength" = 1)
+	duration = 20 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/foodbuff/lavish
+	name = "Lavish Meal"
+	desc = "A meal fit for a king!"
+	icon_state = "foodbuff"
+
+/datum/status_effect/buff/foodbuff/sweet
+	id = "foodbuff-dessert"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/sweet
+	effectedstats = list("perception" = 1,"intelligence" = 1)
+	duration = 10 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/foodbuff/sweet
+	name = "Great Treat"
+	desc = "Something sweet is a rare treat indeed, and helps hone the mind."
+	icon_state = "foodbuff"
+
+/datum/status_effect/buff/foodbuff/sweet/lavish
+	id = "foodbuff-dessert"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/sweet/lavish
+	effectedstats = list("perception" = 1,"intelligence" = 1, "speed" = 1)
+	duration = 10 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/foodbuff/sweet/lavish
+	name = "Decadent Treat"
+	desc = "An exquisite dessert really is something!"
 	icon_state = "foodbuff"
 
 /datum/status_effect/buff/druqks

--- a/code/modules/roguetown/roguejobs/cook/recipes/pies.dm
+++ b/code/modules/roguetown/roguejobs/cook/recipes/pies.dm
@@ -5,20 +5,18 @@
 	icon = 'icons/roguetown/items/food.dmi'
 	icon_state = "pieuncooked"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
-	tastes = list("raw shortdough" = 1)
+	tastes = list("pie" = 1)
 	filling_color = "#FFFFFF"
-	foodtype = GRAIN | DAIRY
+	foodtype = GRAIN | DAIRY | SUGAR
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked
 	slices_num = 0
 	bitesize = 5
 	var/stunning = FALSE
-	var/high_quality = FALSE
 	eat_effect = /datum/status_effect/debuff/uncookedfood
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked
 	icon_state = "pie"
 	desc = ""
-	tastes = list("indulgent buttery, savoury crust")
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/pieslice
 	slices_num = 6
@@ -48,6 +46,8 @@
 		hit_atom.AddComponent(/datum/component/creamed, src)
 	qdel(src)
 
+
+
 /obj/item/reagent_containers/food/snacks/rogue/pie/CheckParts(list/parts_list)
 	..()
 	for(var/obj/item/reagent_containers/food/snacks/M in parts_list)
@@ -59,50 +59,15 @@
 			M.reagents.trans_to(src, M.reagents.total_volume)
 		qdel(M)
 
-// LETHALSTONE ADDITION: give pies qualities based on cooking skill
-/obj/item/reagent_containers/food/snacks/rogue/pie/OnCrafted(dirin, user)
-	. = ..()
-	if (ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/cooking_level = H.mind.get_skill_level(/datum/skill/craft/cooking)
-		if (cooking_level >= SKILL_LEVEL_JOURNEYMAN)
-			var/hq_prob = (cooking_level - 2) * 5
-			var/fortune_modifier = (10-H.STALUC) * 2
-			hq_prob += fortune_modifier
-			if (hq_prob > 0)// && prob(hq_prob))
-				to_chat(H, "This [src] comes together just perfect - I've made something really special!")
-				high_quality = TRUE
-				name = "exquisite [name]"
-				
-/obj/item/reagent_containers/food/snacks/rogue/pie/microwave_act(atom/A)
-	. = ..()
-	if (high_quality) // make sure our high quality stuff carries across
-		var/obj/item/reagent_containers/food/snacks/rogue/pie/new_pie = .
-		new_pie.high_quality = TRUE
-		new_pie.name = "exquisite [name]"
-		if (new_pie.foodtype & SUGAR)
-			new_pie.eat_effect = /datum/status_effect/buff/foodbuff/sweet/lavish
-		else if (new_pie.foodtype & MEAT)
-			new_pie.eat_effect = /datum/status_effect/buff/foodbuff/lavish
-
-/obj/item/reagent_containers/food/snacks/rogue/pie/initialize_slice(obj/item/reagent_containers/food/snacks/slice, reagents_per_slice)
-	. = ..()
-	if (high_quality)
-		slice.name = "exquisite [name]"
-		if (foodtype & SUGAR)
-			slice.eat_effect = /datum/status_effect/buff/foodbuff/sweet/lavish
-		else if (foodtype & MEAT)
-			slice.eat_effect = /datum/status_effect/buff/foodbuff/lavish
-
 /obj/item/reagent_containers/food/snacks/rogue/pieslice
 	icon = 'icons/roguetown/items/food.dmi'
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
-	tastes = list("buttery, savoury crust" = 1)
+	tastes = list("pie" = 1)
 	name = "pie slice"
 	desc = ""
 	icon_state = "slice"
 	filling_color = "#FFFFFF"
-	foodtype = GRAIN | DAIRY 
+	foodtype = GRAIN | DAIRY | SUGAR
 	warming = 10 MINUTES
 	bitesize = 3
 	eat_effect = /datum/status_effect/buff/foodbuff
@@ -129,6 +94,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/rogue/piedough
 
+
 /datum/crafting_recipe/roguetown/cooking/berrypie
 	name = "berry pie"
 	reqs = list(
@@ -137,6 +103,7 @@
 	parts = list(
 		/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 3)
 	result = /obj/item/reagent_containers/food/snacks/rogue/pie/berry
+
 
 /datum/crafting_recipe/roguetown/cooking/applepie
 	name = "apple pie"
@@ -151,31 +118,26 @@
 	name = "berry pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/berry
 	eat_effect = /datum/status_effect/debuff/uncookedfood
-	tastes = list("mushy berries" = 1, "uncooked shortdough" = 1)
-	foodtype = GRAIN | DAIRY | SUGAR
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/berry
 	name = "berry pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
-	eat_effect = /datum/status_effect/buff/foodbuff/sweet
-	tastes = list("sweet, fruity berry jam" = 1, "buttery, sugary crust" = 1)
-	foodtype = GRAIN | DAIRY | SUGAR
+	eat_effect = /datum/status_effect/buff/foodbuff
+	tastes = list("berries" = 1)
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/apple
 	name = "apple pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple
 	eat_effect = /datum/status_effect/debuff/uncookedfood
-	tastes = list("crunchy apples" = 1, "uncooked shortdough" = 1)
-	foodtype = GRAIN | DAIRY | SUGAR
+
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple
 	name = "apple pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
-	eat_effect = /datum/status_effect/buff/foodbuff/sweet
-	tastes = list("stewed and spiced apples" = 1, "buttery, sugary crust" = 1)
-	foodtype = GRAIN | DAIRY | SUGAR
+	eat_effect = /datum/status_effect/buff/foodbuff
+	tastes = list("apples" = 1)
 
 /datum/crafting_recipe/roguetown/cooking/meatpie
 	name = "meat pie"
@@ -193,16 +155,13 @@
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat
 	eat_effect = /datum/status_effect/debuff/uncookedfood
 	filling_color = "#8f433a"
-	tastes = list("uncooked shortdough" = 1, "raw ground meat" = 1)
-	foodtype = GRAIN | DAIRY | MEAT
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat
 	name = "meat pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
 	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("buttery, savoury crust" = 1, "braised, saucy meat" = 1)
-	foodtype = GRAIN | DAIRY | MEAT
+	tastes = list("meat" = 1)
 
 /datum/crafting_recipe/roguetown/cooking/meatpie/fish
 	name = "fish pie"
@@ -215,18 +174,15 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/rogue/pie/meat/fish
 
+
 /obj/item/reagent_containers/food/snacks/rogue/pie/meat/fish
 	name = "fish pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/fish
-	eat_effect = /datum/status_effect/debuff/uncookedfood
-	tastes = list("raw minced fish" = 1, "uncooked shortdough" = 1)
-	foodtype = GRAIN | DAIRY | MEAT
+	tastes = list("fish" = 1)
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/fish
 	name = "fish pie"
-	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("buttery, savoury crust" = 1, "flaky fish" = 1)
-	foodtype = GRAIN | DAIRY | MEAT
+	tastes = list("fish" = 1)
 
 /datum/crafting_recipe/roguetown/cooking/meatpie/poultry
 	name = "pot pie"
@@ -243,15 +199,10 @@
 /obj/item/reagent_containers/food/snacks/rogue/pie/meat/poultry
 	name = "pot pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/poultry
-	eat_effect = /datum/status_effect/debuff/uncookedfood
-	tastes = list("raw minced white meat" = 1, "uncooked shortdough" = 1)
-	foodtype = GRAIN | DAIRY | MEAT
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/poultry
 	name = "pot pie"
-	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("buttery, savoury crust" = 1, "stewed chicken bits" = 1)
-	foodtype = GRAIN | DAIRY | MEAT
+	tastes = list("chicken" = 1)
 
 /datum/crafting_recipe/roguetown/cooking/eggpie
 	name = "egg pie"
@@ -262,17 +213,15 @@
 		/obj/item/reagent_containers/food/snacks/egg = 3)
 	result = /obj/item/reagent_containers/food/snacks/rogue/pie/egg
 
+
 /obj/item/reagent_containers/food/snacks/rogue/pie/egg
 	name = "egg pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/egg
 	eat_effect = /datum/status_effect/debuff/uncookedfood
-	tastes = list("raw egg" = 1, "uncooked shortdough" = 1)
-	foodtype = GRAIN | DAIRY | EGG
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/egg
 	name = "egg pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
 	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("hearty streaks of braised egg" = 1, "buttery, savoury crust" =  1)
-	foodtype = GRAIN | DAIRY | EGG
+	tastes = list("eggs" = 1)

--- a/code/modules/roguetown/roguejobs/cook/recipes/pies.dm
+++ b/code/modules/roguetown/roguejobs/cook/recipes/pies.dm
@@ -5,18 +5,20 @@
 	icon = 'icons/roguetown/items/food.dmi'
 	icon_state = "pieuncooked"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
-	tastes = list("pie" = 1)
+	tastes = list("raw shortdough" = 1)
 	filling_color = "#FFFFFF"
-	foodtype = GRAIN | DAIRY | SUGAR
+	foodtype = GRAIN | DAIRY
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked
 	slices_num = 0
 	bitesize = 5
 	var/stunning = FALSE
+	var/high_quality = FALSE
 	eat_effect = /datum/status_effect/debuff/uncookedfood
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked
 	icon_state = "pie"
 	desc = ""
+	tastes = list("indulgent buttery, savoury crust")
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/pieslice
 	slices_num = 6
@@ -46,8 +48,6 @@
 		hit_atom.AddComponent(/datum/component/creamed, src)
 	qdel(src)
 
-
-
 /obj/item/reagent_containers/food/snacks/rogue/pie/CheckParts(list/parts_list)
 	..()
 	for(var/obj/item/reagent_containers/food/snacks/M in parts_list)
@@ -59,15 +59,50 @@
 			M.reagents.trans_to(src, M.reagents.total_volume)
 		qdel(M)
 
+// LETHALSTONE ADDITION: give pies qualities based on cooking skill
+/obj/item/reagent_containers/food/snacks/rogue/pie/OnCrafted(dirin, user)
+	. = ..()
+	if (ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/cooking_level = H.mind.get_skill_level(/datum/skill/craft/cooking)
+		if (cooking_level >= SKILL_LEVEL_JOURNEYMAN)
+			var/hq_prob = (cooking_level - 2) * 5
+			var/fortune_modifier = (10-H.STALUC) * 2
+			hq_prob += fortune_modifier
+			if (hq_prob > 0)// && prob(hq_prob))
+				to_chat(H, "This [src] comes together just perfect - I've made something really special!")
+				high_quality = TRUE
+				name = "exquisite [name]"
+				
+/obj/item/reagent_containers/food/snacks/rogue/pie/microwave_act(atom/A)
+	. = ..()
+	if (high_quality) // make sure our high quality stuff carries across
+		var/obj/item/reagent_containers/food/snacks/rogue/pie/new_pie = .
+		new_pie.high_quality = TRUE
+		new_pie.name = "exquisite [name]"
+		if (new_pie.foodtype & SUGAR)
+			new_pie.eat_effect = /datum/status_effect/buff/foodbuff/sweet/lavish
+		else if (new_pie.foodtype & MEAT)
+			new_pie.eat_effect = /datum/status_effect/buff/foodbuff/lavish
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/initialize_slice(obj/item/reagent_containers/food/snacks/slice, reagents_per_slice)
+	. = ..()
+	if (high_quality)
+		slice.name = "exquisite [name]"
+		if (foodtype & SUGAR)
+			slice.eat_effect = /datum/status_effect/buff/foodbuff/sweet/lavish
+		else if (foodtype & MEAT)
+			slice.eat_effect = /datum/status_effect/buff/foodbuff/lavish
+
 /obj/item/reagent_containers/food/snacks/rogue/pieslice
 	icon = 'icons/roguetown/items/food.dmi'
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
-	tastes = list("pie" = 1)
+	tastes = list("buttery, savoury crust" = 1)
 	name = "pie slice"
 	desc = ""
 	icon_state = "slice"
 	filling_color = "#FFFFFF"
-	foodtype = GRAIN | DAIRY | SUGAR
+	foodtype = GRAIN | DAIRY 
 	warming = 10 MINUTES
 	bitesize = 3
 	eat_effect = /datum/status_effect/buff/foodbuff
@@ -94,8 +129,6 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/rogue/piedough
 
-
-
 /datum/crafting_recipe/roguetown/cooking/berrypie
 	name = "berry pie"
 	reqs = list(
@@ -104,7 +137,6 @@
 	parts = list(
 		/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 3)
 	result = /obj/item/reagent_containers/food/snacks/rogue/pie/berry
-
 
 /datum/crafting_recipe/roguetown/cooking/applepie
 	name = "apple pie"
@@ -119,26 +151,31 @@
 	name = "berry pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/berry
 	eat_effect = /datum/status_effect/debuff/uncookedfood
+	tastes = list("mushy berries" = 1, "uncooked shortdough" = 1)
+	foodtype = GRAIN | DAIRY | SUGAR
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/berry
 	name = "berry pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
-	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("berries" = 1)
+	eat_effect = /datum/status_effect/buff/foodbuff/sweet
+	tastes = list("sweet, fruity berry jam" = 1, "buttery, sugary crust" = 1)
+	foodtype = GRAIN | DAIRY | SUGAR
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/apple
 	name = "apple pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple
 	eat_effect = /datum/status_effect/debuff/uncookedfood
-
+	tastes = list("crunchy apples" = 1, "uncooked shortdough" = 1)
+	foodtype = GRAIN | DAIRY | SUGAR
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple
 	name = "apple pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
-	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("apples" = 1)
+	eat_effect = /datum/status_effect/buff/foodbuff/sweet
+	tastes = list("stewed and spiced apples" = 1, "buttery, sugary crust" = 1)
+	foodtype = GRAIN | DAIRY | SUGAR
 
 /datum/crafting_recipe/roguetown/cooking/meatpie
 	name = "meat pie"
@@ -156,13 +193,16 @@
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat
 	eat_effect = /datum/status_effect/debuff/uncookedfood
 	filling_color = "#8f433a"
+	tastes = list("uncooked shortdough" = 1, "raw ground meat" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat
 	name = "meat pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
 	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("meat" = 1)
+	tastes = list("buttery, savoury crust" = 1, "braised, saucy meat" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
 
 /datum/crafting_recipe/roguetown/cooking/meatpie/fish
 	name = "fish pie"
@@ -175,15 +215,18 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/rogue/pie/meat/fish
 
-
 /obj/item/reagent_containers/food/snacks/rogue/pie/meat/fish
 	name = "fish pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/fish
-	tastes = list("fish" = 1)
+	eat_effect = /datum/status_effect/debuff/uncookedfood
+	tastes = list("raw minced fish" = 1, "uncooked shortdough" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/fish
 	name = "fish pie"
-	tastes = list("fish" = 1)
+	eat_effect = /datum/status_effect/buff/foodbuff
+	tastes = list("buttery, savoury crust" = 1, "flaky fish" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
 
 /datum/crafting_recipe/roguetown/cooking/meatpie/poultry
 	name = "pot pie"
@@ -200,10 +243,15 @@
 /obj/item/reagent_containers/food/snacks/rogue/pie/meat/poultry
 	name = "pot pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/poultry
+	eat_effect = /datum/status_effect/debuff/uncookedfood
+	tastes = list("raw minced white meat" = 1, "uncooked shortdough" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/poultry
 	name = "pot pie"
-	tastes = list("chicken" = 1)
+	eat_effect = /datum/status_effect/buff/foodbuff
+	tastes = list("buttery, savoury crust" = 1, "stewed chicken bits" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
 
 /datum/crafting_recipe/roguetown/cooking/eggpie
 	name = "egg pie"
@@ -214,15 +262,17 @@
 		/obj/item/reagent_containers/food/snacks/egg = 3)
 	result = /obj/item/reagent_containers/food/snacks/rogue/pie/egg
 
-
 /obj/item/reagent_containers/food/snacks/rogue/pie/egg
 	name = "egg pie"
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/egg
 	eat_effect = /datum/status_effect/debuff/uncookedfood
+	tastes = list("raw egg" = 1, "uncooked shortdough" = 1)
+	foodtype = GRAIN | DAIRY | EGG
 
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/egg
 	name = "egg pie"
 	desc = ""
 	list_reagents = list(/datum/reagent/consumable/nutriment = 30)
 	eat_effect = /datum/status_effect/buff/foodbuff
-	tastes = list("eggs" = 1)
+	tastes = list("hearty streaks of braised egg" = 1, "buttery, savoury crust" =  1)
+	foodtype = GRAIN | DAIRY | EGG

--- a/modular_lethalstone/modules/cooking_improvements/code/buffs.dm
+++ b/modular_lethalstone/modules/cooking_improvements/code/buffs.dm
@@ -1,0 +1,35 @@
+/atom/movable/screen/alert/status_effect/buff/foodbuff
+	desc = "Above-average fare, a rarity in a land like Enigma."
+
+/datum/status_effect/buff/foodbuff/lavish
+	id = "foodbuff"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/lavish
+	effectedstats = list("constitution" = 1, "endurance" = 1, "strength" = 1)
+	duration = 20 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/foodbuff/lavish
+	name = "Lavish Meal"
+	desc = "A meal fit for a king!"
+	icon_state = "foodbuff"
+	
+/datum/status_effect/buff/foodbuff/sweet
+	id = "foodbuff-dessert"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/sweet
+	effectedstats = list("perception" = 1, "intelligence" = 1)
+	duration = 10 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/foodbuff/sweet
+	name = "Great Treat"
+	desc = "Something sweet is a rare treat indeed, and helps hone the mind."
+	icon_state = "foodbuff"
+
+/datum/status_effect/buff/foodbuff/sweet/lavish
+	id = "foodbuff-dessert"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/foodbuff/sweet/lavish
+	effectedstats = list("perception" = 1, "intelligence" = 1, "speed" = 1)
+	duration = 10 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/foodbuff/sweet/lavish
+	name = "Decadent Treat"
+	desc = "An exquisite dessert really is something!"
+	icon_state = "foodbuff"

--- a/modular_lethalstone/modules/cooking_improvements/code/pies.dm
+++ b/modular_lethalstone/modules/cooking_improvements/code/pies.dm
@@ -1,0 +1,89 @@
+// LETHALSTONE ADDITION: give pies qualities based on cooking skill
+/obj/item/reagent_containers/food/snacks/rogue/pie/OnCrafted(dirin, user)
+	. = ..()
+	if (ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/cooking_level = H.mind.get_skill_level(/datum/skill/craft/cooking)
+		if (cooking_level >= SKILL_LEVEL_JOURNEYMAN)
+			var/hq_prob = (cooking_level - 2) * 5
+			var/fortune_modifier = (10-H.STALUC) * 2
+			hq_prob += fortune_modifier
+			if (hq_prob > 0 && prob(hq_prob))
+				to_chat(H, "This [name] comes together just perfect - I've made something really special!")
+				high_quality = TRUE
+				name = "exquisite [name]"
+				
+/obj/item/reagent_containers/food/snacks/rogue/pie/microwave_act(atom/A)
+	. = ..()
+	if (high_quality) // make sure our high quality stuff carries across
+		var/obj/item/reagent_containers/food/snacks/rogue/pie/new_pie = .
+		new_pie.high_quality = TRUE
+		if (new_pie.foodtype & SUGAR)
+			new_pie.eat_effect = /datum/status_effect/buff/foodbuff/sweet/lavish
+		else if (new_pie.foodtype & MEAT)
+			new_pie.eat_effect = /datum/status_effect/buff/foodbuff/lavish
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/initialize_slice(obj/item/reagent_containers/food/snacks/slice, reagents_per_slice)
+	. = ..()
+	if (high_quality)
+		if (foodtype & SUGAR)
+			slice.eat_effect = /datum/status_effect/buff/foodbuff/sweet/lavish
+		else if (foodtype & MEAT)
+			slice.eat_effect = /datum/status_effect/buff/foodbuff/lavish
+
+// Type additions
+
+/obj/item/reagent_containers/food/snacks/rogue/pie
+	/// Is our pie of exceptional quality, and should it give better buffs?
+	var/high_quality = TRUE
+	foodtype = GRAIN | DAIRY
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked
+	tastes = list("indulgent buttery, savoury crust")
+
+/obj/item/reagent_containers/food/snacks/rogue/pieslice
+	foodtype = GRAIN | DAIRY 
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/berry
+	foodtype = GRAIN | DAIRY | SUGAR
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/berry
+	eat_effect = /datum/status_effect/buff/foodbuff/sweet
+	tastes = list("sweet, fruity berry jam" = 1, "buttery, sugary crust" = 1)
+	foodtype = GRAIN | DAIRY | SUGAR
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/apple
+	foodtype = GRAIN | DAIRY | SUGAR
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple
+	eat_effect = /datum/status_effect/buff/foodbuff/sweet
+	tastes = list("stewed and spiced apples" = 1, "buttery, sugary crust" = 1)
+	foodtype = GRAIN | DAIRY | SUGAR
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/meat
+	foodtype = GRAIN | DAIRY | MEAT
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat
+	tastes = list("buttery, savoury crust" = 1, "braised, saucy meat" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/meat/fish
+	foodtype = GRAIN | DAIRY | MEAT
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/fish
+	tastes = list("buttery, savoury crust" = 1, "flaky fish" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/meat/poultry
+	foodtype = GRAIN | DAIRY | MEAT
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/poultry
+	tastes = list("buttery, savoury crust" = 1, "stewed chicken bits" = 1)
+	foodtype = GRAIN | DAIRY | MEAT
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/egg
+	foodtype = GRAIN | DAIRY | EGG
+
+/obj/item/reagent_containers/food/snacks/rogue/pie/cooked/egg
+	tastes = list("hearty streaks of braised egg" = 1, "buttery, savoury crust" =  1)
+	foodtype = GRAIN | DAIRY | EGG

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3492,4 +3492,6 @@
 #include "modular_lethalstone\code\datums\statpacks\agile.dm"
 #include "modular_lethalstone\code\datums\statpacks\physical.dm"
 #include "modular_lethalstone\code\datums\_statpacks.dm"
+#include "modular_lethalstone\modules\cooking_improvements\code\buffs.dm"
+#include "modular_lethalstone\modules\cooking_improvements\code\pies.dm"
 // END_INCLUDE


### PR DESCRIPTION
tl;dr:
- It is now possible to make exquisite pies at and beyond Journeyman cooking skill (increases with skill level and is influenced by fortune).
- Exquisite pies require you to 'craft' the pie first, so they can only be "advanced" pies like berry pies, meat pies, apple pies, etc.
- Exquisite pies give 'lavish' food buffs. For savoury meals, this adds a +1 STR buff to the normal +1 CON and +1 END and *doubles* the duration of the effect to 20 minutes.
- The sweet pies (berry, apple) are now also considered desserts, which give an entirely different food buff. 
- Desserts buff perception and int by +1 for 10 minutes at normal food buff level, and an additional speed +1 for 20 minutes at lavish level.
- You can stack these two buffs together.

I'll probably add a flaw for nobility at later point that makes them crave lavish food buffs once an hour or so.